### PR TITLE
Add bmfs executable to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@
 *.out
 *.app
 
+# UNIX/Linux/Mac Executable
+bmfs
+
 # Mac crap
 .DS_Store


### PR DESCRIPTION
This patch adds "bmfs" to .gitignore so the executable is ignored by git on UNIX/Linux/Mac systems.
