### PR TITLE
Add new "initialize" command to bmfs utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,21 @@
 
 Utility for accessing a disk (or disk image) formatted with BMFS.
 
-## Creating a new disk image ##
+## Creating a new disk image that boots BareMetal-OS ##
+
+    bmfs disk.image initialize 128M path/to/bmfs_mbr.sys path/to/pure64.sys path/to/kernel64.sys
+
+or if the Pure64 boot loader and BareMetal-OS kernel are combined into one file:
+
+    bmfs disk.image initialize 128M path/to/bmfs_mbr.sys path/to/software.sys
+
+
+## Creating a new, formatted disk image ##
+
+    bmfs disk.image initialize 128M
+
+
+## Creating a new, unformatted disk image ##
 
 Linux/Unix/Mac OS X:
 

--- a/bmfs.c
+++ b/bmfs.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 /* Global defines */
 struct BMFSEntry
@@ -16,6 +17,10 @@ struct BMFSEntry
 	unsigned long long Unused;
 };
 
+/* Global constants */
+// Min disk size is 6MiB (three blocks of 2MiB each.)
+const unsigned long long minimumDiskSize = (6 * 1024 * 1024);
+
 /* Global variables */
 FILE *file, *disk;
 unsigned int filesize, disksize;
@@ -24,6 +29,7 @@ char *filename, *diskname, *command;
 char fs_tag[] = "BMFS";
 char s_list[] = "list";
 char s_format[] = "format";
+char s_initialize[] = "initialize";
 char s_create[] = "create";
 char s_read[] = "read";
 char s_write[] = "write";
@@ -39,6 +45,7 @@ char DiskInfo[512];
 int findfile(char *filename, struct BMFSEntry *fileentry, int *entrynumber);
 void list();
 void format();
+int initialize(char *diskname, char *size, char *mbr, char *boot, char *kernel);
 void create(char *filename, unsigned long long maxsize);
 void read(char *filename);
 void write(char *filename);
@@ -54,7 +61,7 @@ int main(int argc, char *argv[])
 		printf("Written by Ian Seyler @ Return Infinity (ian.seyler@returninfinity.com)\n\n");
 		printf("Usage: %s disk function file\n", argv[0]);
 		printf("Disk: the name of the disk file\n");
-		printf("Function: list, read, write, create, delete, format\n");
+		printf("Function: list, read, write, create, delete, format, initialize\n");
 		printf("File: (if applicable)\n");
 		exit(0);
 	}
@@ -62,6 +69,26 @@ int main(int argc, char *argv[])
 	diskname = argv[1];
 	command = argv[2];
 	filename = argv[3];
+
+	if (strcasecmp(s_initialize, command) == 0)
+	{
+		if (argc >= 4)
+		{
+			char *size = argv[3];  // Required
+			char *mbr = (argc > 4 ? argv[4] : NULL);    // Opt.
+			char *boot = (argc > 5 ? argv[5] : NULL);   // Opt.
+			char *kernel = (argc > 6 ? argv[6] : NULL); // Opt.
+			int ret = initialize(diskname, size, mbr, boot, kernel);
+			exit(ret);
+		}
+		else
+		{
+			printf("Usage: %s disk %s ", argv[0], command);
+			printf("size [mbr_file] ");
+			printf("[bootloader_file] [kernel_file]\n");
+			exit(1);
+		}
+	}
 
 	if ((disk = fopen(diskname, "r+b")) == NULL)	// Open for read/write in binary mode
 	{
@@ -163,7 +190,11 @@ int main(int argc, char *argv[])
 	{
 		printf("Unknown command\n");
 	}
-	fclose(disk);
+	if (disk != NULL)
+	{
+		fclose( disk );
+		disk = NULL;
+	}
 	return 0;
 }
 
@@ -233,6 +264,329 @@ void format()
 	fseek(disk, 4096, SEEK_SET);				// Seek 4KiB in for directory
 	fwrite(Directory, 4096, 1, disk);		// Write 4096 bytes for the Directory
 	printf("Format complete.\n");
+}
+
+
+int initialize(char *diskname, char *size, char *mbr, char *boot, char *kernel)
+{
+	unsigned long long diskSize = 0;
+	unsigned long long writeSize = 0;
+	const char *bootFileType = NULL;
+	size_t bufferSize = 50 * 1024;
+	char * buffer = NULL;
+	FILE *mbrFile = NULL;
+	FILE *bootFile = NULL;
+	FILE *kernelFile = NULL;
+	int diskSizeFactor = 0;
+	size_t chunkSize = 0;
+	int ret = 0;
+	size_t i;
+
+	// Determine how the second file will be described in output messages.
+	// If a kernel file is specified too, then assume the second file is the
+	// boot loader.  If no kernel file is specified, assume the boot loader
+	// and kernel are combined into one system file.
+	if (boot != NULL)
+	{
+		bootFileType = "boot loader";
+		if (kernel == NULL)
+		{
+			bootFileType = "system";
+		}
+	}
+
+	// Validate the disk size string and convert it to an integer value.
+	for (i = 0; size[i] != '\0' && ret == 0; ++i)
+	{
+		char ch = size[i];
+		if (isdigit(ch))
+		{
+			unsigned int n = ch - '0';
+			if (diskSize * 10 > diskSize ) // Make sure we don't overflow
+			{
+				diskSize *= 10;
+				diskSize += n;
+			}
+			else if (diskSize == 0) // First loop iteration
+			{
+				diskSize += n;
+			}
+			else
+			{
+				printf("Error: Disk size is too large\n");
+				ret = 1;
+			}
+		}
+		else if (i == 0) // No digits specified
+		{
+			printf("Error: A numeric disk size must be specified\n");
+			ret = 1;
+		}
+		else
+		{
+			switch (toupper(ch))
+			{
+					case 'K':
+						diskSizeFactor = 1;
+						break;
+					case 'M':
+						diskSizeFactor = 2;
+						break;
+					case 'G':
+						diskSizeFactor = 3;
+						break;
+					case 'T':
+						diskSizeFactor = 4;
+						break;
+					case 'P':
+						diskSizeFactor = 5;
+						break;
+					default:
+						printf("Error: Invalid disk size string: '%s'\n", size);
+						ret = 1;
+						break;
+			}
+
+			// If this character is a valid unit indicator, but is not at the
+			// end of the string, then the string is invalid.
+			if (ret == 0 && size[i+1] != '\0')
+			{
+				printf("Error: Invalid disk size string: '%s'\n", size);
+				ret = 1;
+			}
+		}
+	}
+
+	// Adjust the disk size if a unit indicator was given.  Note that an
+	// input of something like "0" or "0K" will get past the checks above.
+	if (ret == 0 && diskSize > 0 && diskSizeFactor > 0)
+	{
+		while (diskSizeFactor--)
+		{
+			if (diskSize * 1024 > diskSize ) // Make sure we don't overflow
+			{
+				diskSize *= 1024;
+			}
+			else
+			{
+				printf("Error: Disk size is too large\n");
+				ret = 1;
+			}
+		}
+	}
+
+	// Make sure the disk size is large enough.
+	if (ret == 0)
+	{
+		if (diskSize < minimumDiskSize)
+		{
+			printf( "Error: Disk size must be at least %llu bytes (%lluMiB)\n", minimumDiskSize, minimumDiskSize / (1024*1024));
+			ret = 1;
+		}
+	}
+
+	// Open the Master boot Record file for reading.
+	if (ret == 0 && mbr != NULL)
+	{
+		mbrFile = fopen(mbr, "rb");
+		if (mbrFile == NULL )
+		{
+			printf("Error: Unable to open MBR file '%s'\n", mbr);
+			ret = 1;
+		}
+	}
+
+	// Open the boot loader file for reading.
+	if (ret == 0 && boot != NULL)
+	{
+		bootFile = fopen(boot, "rb");
+		if (bootFile == NULL )
+		{
+			printf("Error: Unable to open %s file '%s'\n", bootFileType, boot);
+			ret = 1;
+		}
+	}
+
+	// Open the kernel file for reading.
+	if (ret == 0 && kernel != NULL)
+	{
+		kernelFile = fopen(kernel, "rb");
+		if (kernelFile == NULL )
+		{
+			printf("Error: Unable to open kernel file '%s'\n", kernel);
+			ret = 1;
+		}
+	}
+
+	// Allocate buffer to use for filling the disk image with zeros.
+	if (ret == 0)
+	{
+		buffer = (char *) malloc(bufferSize);
+		if (buffer == NULL)
+		{
+			printf("Error: Failed to allocate buffer\n");
+			ret = 1;
+		}
+	}
+
+	// Open the disk image file for writing.  This will truncate the disk file
+	// if it already exists, so we should do this only after we're ready to
+	// actually write to the file.
+	if (ret == 0)
+	{
+		disk = fopen(diskname, "wb");
+		if (disk == NULL)
+		{
+			printf("Error: Unable to open disk '%s'\n", diskname);
+			ret = 1;
+		}
+	}
+
+	// Fill the disk image with zeros.
+	if (ret == 0)
+	{
+		double percent;
+		memset(buffer, 0, bufferSize);
+		writeSize = 0;
+		while (writeSize < diskSize)
+		{
+			percent = writeSize;
+			percent /= diskSize;
+			percent *= 100;
+			printf("Formatting disk: %llu of %llu bytes (%.0f%%)...\r", writeSize, diskSize, percent);
+			chunkSize = bufferSize;
+			if (chunkSize > diskSize - writeSize)
+			{
+				chunkSize = diskSize - writeSize;
+			}
+			if (fwrite(buffer, chunkSize, 1, disk) != 1)
+			{
+				printf("Error: Failed to write disk '%s'\n", diskname);
+				ret = 1;
+				break;
+			}
+			writeSize += chunkSize;
+		}
+		if (ret == 0)
+		{
+			printf("Formatting disk: %llu of %llu bytes (100%%)%9s\n", writeSize, diskSize, "");
+		}
+	}
+
+	// Format the disk.
+	if (ret == 0)
+	{
+		rewind(disk);
+		format();
+	}
+
+	// Write the master boot record if it was specified by the caller.
+	if (ret == 0 && mbrFile !=NULL)
+	{
+		printf("Writing master boot record.\n");
+		fseek(disk, 0, SEEK_SET);
+		if (fread(buffer, 512, 1, mbrFile) == 1)
+		{
+			if (fwrite(buffer, 512, 1, disk) != 1)
+			{
+				printf("Error: Failed to write disk '%s'\n", diskname);
+				ret = 1;
+			}
+		}
+		else
+		{
+			printf("Error: Failed to read file '%s'\n", mbr);
+			ret = 1;
+		}
+	}
+
+	// Write the boot loader if it was specified by the caller.
+	if (ret == 0 && bootFile !=NULL)
+	{
+		printf("Writing %s file.\n", bootFileType);
+		fseek(disk, 8192, SEEK_SET);
+		for (;;)
+		{
+			chunkSize = fread( buffer, 1, bufferSize, bootFile);
+			if (chunkSize > 0)
+			{
+				if (fwrite(buffer, chunkSize, 1, disk) != 1)
+				{
+					printf("Error: Failed to write disk '%s'\n", diskname);
+					ret = 1;
+				}
+			}
+			else
+			{
+				if (ferror(disk))
+				{
+					printf("Error: Failed to read file '%s'\n", boot);
+					ret = 1;
+				}
+				break;
+			}
+		}
+	}
+
+	// Write the kernel if it was specified by the caller. The kernel must
+	// immediately follow the boot loader on disk (i.e. no seek needed.)
+	if (ret == 0 && kernelFile !=NULL)
+	{
+		printf("Writing kernel.\n");
+		for (;;)
+		{
+			chunkSize = fread( buffer, 1, bufferSize, kernelFile);
+			if (chunkSize > 0)
+			{
+				if (fwrite(buffer, chunkSize, 1, disk) != 1)
+				{
+					printf("Error: Failed to write disk '%s'\n", diskname);
+					ret = 1;
+				}
+			}
+			else
+			{
+				if (ferror(disk))
+				{
+					printf("Error: Failed to read file '%s'\n", kernel);
+					ret = 1;
+				}
+				break;
+			}
+		}
+	}
+
+	// Close any files that were opened.
+	if (mbrFile != NULL)
+	{
+		fclose(mbrFile);
+	}
+	if (bootFile != NULL)
+	{
+		fclose(bootFile);
+	}
+	if (kernelFile != NULL)
+	{
+		fclose(kernelFile);
+	}
+	if (disk != NULL)
+	{
+		fclose(disk);
+		disk = NULL;
+	}
+
+	// Free the buffer if it was allocated.
+	if (buffer != NULL)
+	{
+		free(buffer);
+	}
+
+	if (ret == 0)
+	{
+		printf("Disk initialization complete.\n");
+	}
+
+	return ret;
 }
 
 


### PR DESCRIPTION
This commit adds a new "initialize" command to the bmfs utility and
updates the README.md document with examples of how to use it.

The initialize command eliminates the need to use "dd" or another similar
program to create a disk image.  It performs the following operations in
one invocation:
1) Creates a new disk image of a specified size.
2) Formats the disk image.
3) Optionally writes MBR, boot loader, and kernel files onto the disk image.
