### PR TITLE
added strcasecmp for msvc

### DIFF
--- a/src/bmfs.c
+++ b/src/bmfs.c
@@ -7,8 +7,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <ctype.h>
+
+#ifdef _MSC_VER
+static int strcasecmp(const char *str1, const char *str2);
+#else /* _MSC_VER */
+#include <strings.h>
+#endif /* _MSC_VER */
 
 /* Typedefs */
 typedef uint8_t u8;
@@ -865,5 +870,10 @@ void delete(char *filename)
 	}
 }
 
+#ifdef _MSC_VER
+static int strcasecmp(const char *str1, const char *str2){
+	return _stricmp(str1, str2);
+}
+#endif /* _MSC_VER */
 
 /* EOF */


### PR DESCRIPTION
Tested on:
- Windows 10 with MSVC 19.00.23506 for x86.
- Windows 10 with MSVC 19.00.23506 for x64
- Ubuntu 14.04 (server) with autoreconf 2.69 and gcc 4.8.4.
