### PR TITLE
using standard makefile variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+CFLAGS = -Wall -W -pedantic -std=c99
+VPATH = src
+
+.PHONY: all
 all: bmfs
 
-bmfs: src/bmfs.c
-	$(CC) -o bmfs src/bmfs.c -Wall -W -pedantic -std=c99
+bmfs: bmfs.c
 
+.PHONY: clean
 clean:
-	rm -f bmfs
+	$(RM) bmfs
 


### PR DESCRIPTION
Leveraging GNU Make's implicit rules and the `VPATH` variable to remove manually typed command. Also replaced `rm -f` with the variable `RM`, which makefile defines as `rm -f`.