### PR TITLE
Accounting for bmfs-fuse in top level makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@
 all:
 	$(MAKE) -C src all
 	cp --update src/bmfs bmfs
+ifndef NO_FUSE
 	cp --update src/bmfs-fuse bmfs-fuse
+endif
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ endif
 .PHONY: clean
 clean:
 	$(MAKE) -C src clean
+	$(RM) bmfs bmfs-fuse
 
 .PHONY: help
 help:


### PR DESCRIPTION
The fuse program is only being copied if `NO_FUSE` isn't defined and `bmfs_fuse` was added to clean target.