### PR TITLE
Fixed Fuse Bug

### DIFF
--- a/include/bmfs/disk.h
+++ b/include/bmfs/disk.h
@@ -125,7 +125,7 @@ int bmfs_disk_write(struct BMFSDisk *disk,
  */
 
 int bmfs_disk_bytes(struct BMFSDisk *disk,
-                    size_t *bytes);
+                    uint64_t *bytes);
 
 /** Determines the number of mebibytes
  * available on disk.
@@ -139,7 +139,7 @@ int bmfs_disk_bytes(struct BMFSDisk *disk,
  */
 
 int bmfs_disk_mebibytes(struct BMFSDisk *disk,
-                        size_t *mebibytes);
+                        uint64_t *mebibytes);
 
 /** Determines the number of blocks
  * available on disk.
@@ -153,7 +153,7 @@ int bmfs_disk_mebibytes(struct BMFSDisk *disk,
  */
 
 int bmfs_disk_blocks(struct BMFSDisk *disk,
-                     size_t *blocks);
+                     uint64_t *blocks);
 
 /** Locates a starting block that can
  * fit a certain number of bytes.
@@ -170,8 +170,8 @@ int bmfs_disk_blocks(struct BMFSDisk *disk,
  */
 
 int bmfs_disk_allocate_bytes(struct BMFSDisk *disk,
-                             size_t bytes,
-                             size_t *starting_block);
+                             uint64_t bytes,
+                             uint64_t *starting_block);
 
 /** Locates a starting block that can
  * fit a certain number of mebibytes.
@@ -187,8 +187,8 @@ int bmfs_disk_allocate_bytes(struct BMFSDisk *disk,
  */
 
 int bmfs_disk_allocate_mebibytes(struct BMFSDisk *disk,
-                                 size_t mebibytes,
-                                 size_t *starting_block);
+                                 uint64_t mebibytes,
+                                 uint64_t *starting_block);
 
 /** Locates a file entry.
  * @param disk An initialized disk.
@@ -277,7 +277,7 @@ int bmfs_disk_write_tag(struct BMFSDisk *disk);
 
 int bmfs_disk_create_file(struct BMFSDisk *disk,
                           const char *filename,
-                          size_t mebibytes);
+                          uint64_t mebibytes);
 
 /** Deletes a file from the disk.
  * If the file doesn't exist, this

--- a/src/disk-test.c
+++ b/src/disk-test.c
@@ -82,22 +82,8 @@ static int data_write(void *disk_ptr, const void *buf, uint64_t len, uint64_t *w
 	return 0;
 }
 
-static int zerocmp(const void *a, size_t size)
-{
-	void *b = calloc(1, size);
-	if (b == NULL)
-		return -1;
-
-	int cmp_result = memcmp(a, b, size);
-
-	free(b);
-
-	return cmp_result;
-}
-
 int main(void)
 {
-
 	struct DiskData data;
 
 	data.buf = malloc(BMFS_MINIMUM_DISK_SIZE);
@@ -116,7 +102,6 @@ int main(void)
 	/* test format function */
 	assert(bmfs_disk_format(&disk) == 0);
 	assert(memcmp(&data.buf[1024], "BMFS", 4) == 0);
-	assert(zerocmp(&data.buf[4096], 4096) == 0);
 
 	/* test allocation */
 	uint64_t starting_block = 0;
@@ -136,8 +121,6 @@ int main(void)
 	assert(dir.Entries[0].FileSize == 0);
 	/* make sure buffer is consistent */
 	assert(memcmp(&data.buf[4096], "a.txt", 5) == 0);
-	/* make sure next file marks end of directory */
-	assert(dir.Entries[1].FileName[0] == 0);
 
 	assert(bmfs_disk_create_file(&disk, "b.txt", 1) == 0);
 	assert(bmfs_disk_read_dir(&disk, &dir) == 0);
@@ -148,8 +131,6 @@ int main(void)
 	/* make sure buffer is consistent */
 	assert(memcmp(&data.buf[4096], "a.txt", 5) == 0);
 	assert(memcmp(&data.buf[4096 + 64], "b.txt", 5) == 0);
-	/* make sure next file marks end of directory */
-	assert(dir.Entries[2].FileName[0] == 0);
 
 	/* test to make sure the disk will run out of space */
 	assert(bmfs_disk_create_file(&disk, "c.txt", 1) == -ENOSPC);

--- a/src/disk.c
+++ b/src/disk.c
@@ -77,7 +77,7 @@ int bmfs_disk_write_dir(struct BMFSDisk *disk, const struct BMFSDir *dir)
 	return 0;
 }
 
-int bmfs_disk_allocate_bytes(struct BMFSDisk *disk, size_t bytes, size_t *starting_block)
+int bmfs_disk_allocate_bytes(struct BMFSDisk *disk, uint64_t bytes, uint64_t *starting_block)
 {
 	if ((disk == NULL)
 	 || (starting_block == NULL))
@@ -98,17 +98,17 @@ int bmfs_disk_allocate_bytes(struct BMFSDisk *disk, size_t bytes, size_t *starti
 	if (err != 0)
 		return err;
 
-	size_t total_blocks;
+	uint64_t total_blocks;
 	err = bmfs_disk_blocks(disk, &total_blocks);
 	if (err != 0)
 		return err;
 	else if (total_blocks == 0)
 		return -ENOSPC;
 
-	size_t prev_block = 1;
-	size_t next_block = total_blocks;
+	uint64_t prev_block = 1;
+	uint64_t next_block = total_blocks;
 
-	for (size_t i = 0; i < 64; i++)
+	for (uint64_t i = 0; i < 64; i++)
 	{
 		struct BMFSEntry *entry = &dir.Entries[i];
 		if (!(bmfs_entry_is_empty(entry))
@@ -130,12 +130,12 @@ int bmfs_disk_allocate_bytes(struct BMFSDisk *disk, size_t bytes, size_t *starti
 	return -ENOSPC;
 }
 
-int bmfs_disk_allocate_mebibytes(struct BMFSDisk *disk, size_t mebibytes, size_t *starting_block)
+int bmfs_disk_allocate_mebibytes(struct BMFSDisk *disk, uint64_t mebibytes, uint64_t *starting_block)
 {
 	return bmfs_disk_allocate_bytes(disk, mebibytes * 1024 * 1024, starting_block);
 }
 
-int bmfs_disk_bytes(struct BMFSDisk *disk, size_t *bytes)
+int bmfs_disk_bytes(struct BMFSDisk *disk, uint64_t *bytes)
 {
 	if (disk == NULL)
 		return -EFAULT;
@@ -155,7 +155,7 @@ int bmfs_disk_bytes(struct BMFSDisk *disk, size_t *bytes)
 	return 0;
 }
 
-int bmfs_disk_mebibytes(struct BMFSDisk *disk, size_t *mebibytes)
+int bmfs_disk_mebibytes(struct BMFSDisk *disk, uint64_t *mebibytes)
 {
 	if (disk == NULL)
 		return -EFAULT;
@@ -170,7 +170,7 @@ int bmfs_disk_mebibytes(struct BMFSDisk *disk, size_t *mebibytes)
 	return 0;
 }
 
-int bmfs_disk_blocks(struct BMFSDisk *disk, size_t *blocks)
+int bmfs_disk_blocks(struct BMFSDisk *disk, uint64_t *blocks)
 {
 	if (disk == NULL)
 		return -EFAULT;
@@ -185,7 +185,7 @@ int bmfs_disk_blocks(struct BMFSDisk *disk, size_t *blocks)
 	return 0;
 }
 
-int bmfs_disk_create_file(struct BMFSDisk *disk, const char *filename, size_t mebibytes)
+int bmfs_disk_create_file(struct BMFSDisk *disk, const char *filename, uint64_t mebibytes)
 {
 	if ((disk == NULL)
 	 || (filename == NULL))
@@ -194,7 +194,7 @@ int bmfs_disk_create_file(struct BMFSDisk *disk, const char *filename, size_t me
 	if (mebibytes % 2 != 0)
 		mebibytes++;
 
-	size_t starting_block;
+	uint64_t starting_block;
 	int err = bmfs_disk_allocate_mebibytes(disk, mebibytes, &starting_block);
 	if (err != 0)
 		return err;


### PR DESCRIPTION
This pull request fixes a bug I found with the fuse implementation I wrote a while ago.

It turns out, the fuse implementation couldn't read and write files (only create and delete them). This pull request fixes the read and write methods of the fuse implementation.

During this bug fixed, I was building on a 32-bit platform. This revealed to me that some of the type conversions from `uint64_t` to `size_t` were incorrect, since `size_t` is four bytes on 32-bit platforms. I corrected this. I also realized, on 32-bit platforms, that BMFS will probably break when dealing with disks larger than computable by a long int. This has to do with the fact that `long int` may only be 32-bits large on 32-bit platforms. I left this unfixed for now, because it may require using platform-specific code for the BMFS programs.

I also updated the disk test to skip requirements of the file system that are no longer needed.